### PR TITLE
Fix : Implement WarningNotifications when Users access a SecureArea

### DIFF
--- a/src/main/java/kr/co/monitoringserver/controller/api/AttendanceApiController.java
+++ b/src/main/java/kr/co/monitoringserver/controller/api/AttendanceApiController.java
@@ -24,28 +24,28 @@ public class AttendanceApiController {
     /**
      * Create And Save User Clock In Controller
      */
-    @PostMapping("/clock_in/{user_identity}")
-    public ResponseFormat<Void> createAndSaveUserClockIn(@PathVariable(name = "user_identity") String userIdentity) {
+    @PostMapping("/clock_in")
+    public ResponseFormat<Void> createAndSaveUserClockIn(Principal principal) {
 
-        attendanceService.createAndSaveUserClockIn(userIdentity);
+        attendanceService.createAndSaveUserClockIn(principal);
 
         return ResponseFormat.successMessage(
                 ResponseStatus.SUCCESS_CREATED,
-                userIdentity + "님 출근이 성공적으로 저장되었습니다"
+                principal.getName() + "님 출근이 성공적으로 저장되었습니다"
         );
     }
 
     /**
      * Update And Save User Clock Out Controller
      */
-    @PutMapping("/clock_out/{user_identity}")
-    public ResponseFormat<Void> updateAndSaveUserClockOut(@PathVariable(name = "user_identity") String userIdentity) {
+    @PutMapping("/clock_out")
+    public ResponseFormat<Void> updateAndSaveUserClockOut(Principal principal) {
 
-        attendanceService.updateAndSaveUserClockOut(userIdentity);
+        attendanceService.updateAndSaveUserClockOut(principal);
 
         return ResponseFormat.successMessage(
                 ResponseStatus.SUCCESS_CREATED,
-                userIdentity + "님 퇴근이 성공적으로 저장되었습니다"
+                principal.getName() + "님 퇴근이 성공적으로 저장되었습니다"
         );
     }
 

--- a/src/main/java/kr/co/monitoringserver/controller/api/AttendanceApiController.java
+++ b/src/main/java/kr/co/monitoringserver/controller/api/AttendanceApiController.java
@@ -24,28 +24,28 @@ public class AttendanceApiController {
     /**
      * Create And Save User Clock In Controller
      */
-    @PostMapping("/clock_in")
-    public ResponseFormat<Void> createAndSaveUserClockIn(Principal principal) {
+    @PostMapping("/clock_in/{user_identity}")
+    public ResponseFormat<Void> createAndSaveUserClockIn(@PathVariable(name = "user_identity") String userIdentity) {
 
-        attendanceService.createAndSaveUserClockIn(principal);
+        attendanceService.createAndSaveUserClockIn(userIdentity);
 
         return ResponseFormat.successMessage(
                 ResponseStatus.SUCCESS_CREATED,
-                principal.getName() + "님 출근이 성공적으로 저장되었습니다"
+                userIdentity + "님 출근이 성공적으로 저장되었습니다"
         );
     }
 
     /**
      * Update And Save User Clock Out Controller
      */
-    @PutMapping("/clock_out")
-    public ResponseFormat<Void> updateAndSaveUserClockOut(Principal principal) {
+    @PutMapping("/clock_out/{user_identity}")
+    public ResponseFormat<Void> updateAndSaveUserClockOut(@PathVariable(name = "user_identity") String userIdentity) {
 
-        attendanceService.updateAndSaveUserClockOut(principal);
+        attendanceService.updateAndSaveUserClockOut(userIdentity);
 
         return ResponseFormat.successMessage(
                 ResponseStatus.SUCCESS_CREATED,
-                principal.getName() + "님 퇴근이 성공적으로 저장되었습니다"
+                userIdentity + "님 퇴근이 성공적으로 저장되었습니다"
         );
     }
 

--- a/src/main/java/kr/co/monitoringserver/controller/api/SecurityAreaApiController.java
+++ b/src/main/java/kr/co/monitoringserver/controller/api/SecurityAreaApiController.java
@@ -55,12 +55,12 @@ public class SecurityAreaApiController {
     /**
      * Update Security Area Controller
      */
-    @PutMapping("/{security_area_id}/{user_identity}")
+    @PutMapping("/{security_area_id}")
     public ResponseFormat<Void> updateSecurityArea(@PathVariable(name = "security_area_id") Long securityAreaId,
                                                    @RequestBody @Validated SecurityAreaReqDTO.UPDATE update,
-                                                   @PathVariable(name = "user_identity") String userIdentity) {
+                                                   Principal principal) {
 
-        securityAreaService.updateSecurityArea(userIdentity, securityAreaId, update);
+        securityAreaService.updateSecurityArea(principal, securityAreaId, update);
 
         return ResponseFormat.successMessage(
                 ResponseStatus.SUCCESS_EXECUTE,
@@ -109,11 +109,11 @@ public class SecurityAreaApiController {
     @GetMapping("/access_log/{security_area_id}")
     public ResponseFormat<Page<SecurityAreaLocationResDTO.READ>> getUserSecurityAreaAccessLogs(@PathVariable(name = "security_area_id") Long securityAreaId,
                                                                                                @PageableDefault Pageable pageable,
-                                                                                               @PathVariable(name = "user_identity") String userIdentity) {
+                                                                                               Principal principal) {
 
         return ResponseFormat.successData(
                 ResponseStatus.SUCCESS_EXECUTE,
-                securityAreaService.getUserSecurityAreaAccessLogs(userIdentity, securityAreaId, pageable)
+                securityAreaService.getUserSecurityAreaAccessLogs(principal, securityAreaId, pageable)
         );
     }
 }

--- a/src/main/java/kr/co/monitoringserver/controller/api/SecurityAreaApiController.java
+++ b/src/main/java/kr/co/monitoringserver/controller/api/SecurityAreaApiController.java
@@ -109,11 +109,11 @@ public class SecurityAreaApiController {
     @GetMapping("/access_log/{security_area_id}")
     public ResponseFormat<Page<SecurityAreaLocationResDTO.READ>> getUserSecurityAreaAccessLogs(@PathVariable(name = "security_area_id") Long securityAreaId,
                                                                                                @PageableDefault Pageable pageable,
-                                                                                               Principal principal) {
+                                                                                               @PathVariable(name = "user_identity") String userIdentity) {
 
         return ResponseFormat.successData(
                 ResponseStatus.SUCCESS_EXECUTE,
-                securityAreaService.getUserSecurityAreaAccessLogs(principal, securityAreaId, pageable)
+                securityAreaService.getUserSecurityAreaAccessLogs(userIdentity, securityAreaId, pageable)
         );
     }
 }

--- a/src/main/java/kr/co/monitoringserver/persistence/entity/alert/SecurityAreaWarning.java
+++ b/src/main/java/kr/co/monitoringserver/persistence/entity/alert/SecurityAreaWarning.java
@@ -22,7 +22,7 @@ public class SecurityAreaWarning extends BaseEntity {
     private SecurityArea securityArea;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "alert_id")
+    @JoinColumn(name = "warning_notification_id")
     private WarningNotification warningNotification;
 
 

--- a/src/main/java/kr/co/monitoringserver/service/service/alert/WarningNotificationService.java
+++ b/src/main/java/kr/co/monitoringserver/service/service/alert/WarningNotificationService.java
@@ -23,7 +23,9 @@ public class WarningNotificationService {
     public void createAndSendWarningNotification(User user) {
 
         WarningNotification warningNotification =
-                warningNotificationMapper.toWarningNotificationEntity(LocalTime.now(), "주의 : 보안구역에 진입하였습니다");
+                warningNotificationMapper.toWarningNotificationEntity(
+                        LocalTime.now(),
+                        "주의 : " + user.getName() + "님이 보안구역에 진입하였습니다");
 
         warningNotificationRepository.save(warningNotification);
 

--- a/src/main/java/kr/co/monitoringserver/service/service/attendance/AttendanceService.java
+++ b/src/main/java/kr/co/monitoringserver/service/service/attendance/AttendanceService.java
@@ -46,9 +46,9 @@ public class AttendanceService {
      * Create And Save User Clock In Service
      */
     @Transactional
-    public void createAndSaveUserClockIn(String userIdentity) {
+    public void createAndSaveUserClockIn(Principal principal) {
 
-        final User user = userRepository.findByIdentity(userIdentity)
+        final User user = userRepository.findByIdentity(principal.getName())
                 .orElseThrow(BadRequestException::new);
 
         isAttendanceAlreadyTakenOnDate(user, LocalDate.now());
@@ -70,9 +70,9 @@ public class AttendanceService {
      * Update And Save User Clock Out Service
      */
     @Transactional
-    public void updateAndSaveUserClockOut(String userIdentity) {
+    public void updateAndSaveUserClockOut(Principal principal) {
 
-        final User user = userRepository.findByIdentity(userIdentity)
+        final User user = userRepository.findByIdentity(principal.getName())
                 .orElseThrow(BadRequestException::new);
 
         LocalDate today = LocalDate.now();

--- a/src/main/java/kr/co/monitoringserver/service/service/attendance/AttendanceService.java
+++ b/src/main/java/kr/co/monitoringserver/service/service/attendance/AttendanceService.java
@@ -46,9 +46,9 @@ public class AttendanceService {
      * Create And Save User Clock In Service
      */
     @Transactional
-    public void createAndSaveUserClockIn(Principal principal) {
+    public void createAndSaveUserClockIn(String userIdentity) {
 
-        final User user = userRepository.findByIdentity(principal.getName())
+        final User user = userRepository.findByIdentity(userIdentity)
                 .orElseThrow(BadRequestException::new);
 
         isAttendanceAlreadyTakenOnDate(user, LocalDate.now());
@@ -68,12 +68,11 @@ public class AttendanceService {
 
     /**
      * Update And Save User Clock Out Service
-     * 이미 퇴근했던 기록이 있어도 퇴근을 누르면 퇴근이 진행됨 : 해당 날짜에 퇴근을 하게 되면 다시 퇴근을 못하게 막을지 그냥 둘지 고민해봐야 할거 같음
      */
     @Transactional
-    public void updateAndSaveUserClockOut(Principal principal) {
+    public void updateAndSaveUserClockOut(String userIdentity) {
 
-        final User user = userRepository.findByIdentity(principal.getName())
+        final User user = userRepository.findByIdentity(userIdentity)
                 .orElseThrow(BadRequestException::new);
 
         LocalDate today = LocalDate.now();
@@ -211,7 +210,7 @@ public class AttendanceService {
         }
     }
 
-    // 출/퇴근 상태를 통해 출근 리스트를 조회
+    // 출 / 퇴근 상태를 통해 출근 리스트를 조회
     private Page<AttendanceResDTO.READ> getAttendanceListByStatus(LocalDate date, AttendanceType status, Pageable pageable) {
 
         final Page<UserAttendance> userAttendancePage = userAttendanceRepository.findByAttendance_Date(date, pageable);

--- a/src/main/java/kr/co/monitoringserver/service/service/beacon/BeaconService.java
+++ b/src/main/java/kr/co/monitoringserver/service/service/beacon/BeaconService.java
@@ -291,7 +291,6 @@ public class BeaconService {
     }
 
     // 비콘 배터리가 20% 미만일 경우 알림 설정
-    // TODO : 생성된 경고알림 정보를 경고알림 Repository 저장
     private void sendBatteryLowNotification(Beacon beacon) {
 
         System.out.printf(

--- a/src/main/java/kr/co/monitoringserver/service/service/securityArea/SecurityAreaService.java
+++ b/src/main/java/kr/co/monitoringserver/service/service/securityArea/SecurityAreaService.java
@@ -98,9 +98,9 @@ public class SecurityAreaService {
      * Update Security Area Service
      */
     @Transactional
-    public void updateSecurityArea(String userIdentity, Long securityAreaId, SecurityAreaReqDTO.UPDATE update) {
+    public void updateSecurityArea(Principal principal, Long securityAreaId, SecurityAreaReqDTO.UPDATE update) {
 
-        checkUserAuthorization(userIdentity);
+        checkUserAuthorization(principal.getName());
 
         final SecurityArea securityArea = securityAreaRepository.findById(securityAreaId)
                 .orElseThrow(() -> new NotFoundException(ResponseStatus.NOT_FOUND_SECURITY_AREA));
@@ -187,9 +187,9 @@ public class SecurityAreaService {
     /**
      * Get User Security Area Access Logs Service
      */
-    public Page<SecurityAreaLocationResDTO.READ> getUserSecurityAreaAccessLogs(String userIdentity, Long securityAreaId, Pageable pageable) {
+    public Page<SecurityAreaLocationResDTO.READ> getUserSecurityAreaAccessLogs(Principal principal, Long securityAreaId, Pageable pageable) {
 
-        final User user = userRepository.findByIdentity(userIdentity)
+        final User user = userRepository.findByIdentity(principal.getName())
                 .orElseThrow(BadRequestException::new);
 
         final SecurityArea securityArea = securityAreaRepository.findById(securityAreaId)

--- a/src/main/java/kr/co/monitoringserver/service/service/securityArea/SecurityAreaService.java
+++ b/src/main/java/kr/co/monitoringserver/service/service/securityArea/SecurityAreaService.java
@@ -3,7 +3,6 @@ package kr.co.monitoringserver.service.service.securityArea;
 import kr.co.monitoringserver.controller.api.AdminApiController;
 import kr.co.monitoringserver.infra.global.exception.BadRequestException;
 import kr.co.monitoringserver.infra.global.exception.NotFoundException;
-import kr.co.monitoringserver.infra.global.exception.UnAuthenticateException;
 import kr.co.monitoringserver.infra.global.model.ResponseStatus;
 import kr.co.monitoringserver.persistence.entity.alert.IndexNotification;
 import kr.co.monitoringserver.persistence.entity.securityArea.SecurityArea;
@@ -11,7 +10,6 @@ import kr.co.monitoringserver.persistence.entity.user.User;
 import kr.co.monitoringserver.persistence.repository.IndexNotificationRepository;
 import kr.co.monitoringserver.persistence.repository.SecurityAreaRepository;
 import kr.co.monitoringserver.persistence.repository.UserRepository;
-import kr.co.monitoringserver.persistence.repository.UserSecurityAreaRepository;
 import kr.co.monitoringserver.service.dtos.request.securityArea.SecurityAreaLocationReqDTO;
 import kr.co.monitoringserver.service.dtos.request.securityArea.SecurityAreaReqDTO;
 import kr.co.monitoringserver.service.dtos.response.SecurityAreaLocationResDTO;
@@ -23,7 +21,6 @@ import lombok.RequiredArgsConstructor;
 import org.json.simple.JSONObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -46,7 +43,6 @@ public class SecurityAreaService {
     private final UserRepository userRepository;
 
     private final SecurityAreaLocationService securityAreaLocationService;
-    private final UserSecurityAreaRepository userSecurityAreaRepository;
 
     private final IndexNotificationRepository indexNotificationRepository;
 
@@ -191,9 +187,9 @@ public class SecurityAreaService {
     /**
      * Get User Security Area Access Logs Service
      */
-    public Page<SecurityAreaLocationResDTO.READ> getUserSecurityAreaAccessLogs(Principal principal, Long securityAreaId, Pageable pageable) {
+    public Page<SecurityAreaLocationResDTO.READ> getUserSecurityAreaAccessLogs(String userIdentity, Long securityAreaId, Pageable pageable) {
 
-        final User user = userRepository.findByIdentity(principal.getName())
+        final User user = userRepository.findByIdentity(userIdentity)
                 .orElseThrow(BadRequestException::new);
 
         final SecurityArea securityArea = securityAreaRepository.findById(securityAreaId)
@@ -213,7 +209,7 @@ public class SecurityAreaService {
         if (user.getUserRoleType().equals(UserRoleType.ADMIN)) {
             return true;
         } else {
-            throw new UnAuthenticateException();
+            return false;
         }
     }
 }

--- a/src/main/java/kr/co/monitoringserver/service/service/user/UserService.java
+++ b/src/main/java/kr/co/monitoringserver/service/service/user/UserService.java
@@ -5,9 +5,7 @@ import kr.co.monitoringserver.infra.global.model.ResponseStatus;
 import kr.co.monitoringserver.persistence.entity.Location;
 import kr.co.monitoringserver.persistence.entity.attendance.UserAttendance;
 import kr.co.monitoringserver.persistence.entity.user.User;
-import kr.co.monitoringserver.persistence.repository.BeaconRepository;
 import kr.co.monitoringserver.persistence.repository.UserAttendanceRepository;
-import kr.co.monitoringserver.persistence.repository.UserBeaconRepository;
 import kr.co.monitoringserver.persistence.repository.UserRepository;
 import kr.co.monitoringserver.service.dtos.request.user.UserReqDTO;
 import kr.co.monitoringserver.service.enums.AttendanceType;
@@ -37,10 +35,6 @@ public class UserService {
     private final BCryptPasswordEncoder encoder;
 
     private final UserLocationService userLocationService;
-
-    private final BeaconRepository beaconRepository;
-
-    private final UserBeaconRepository userBeaconRepository;
 
     /**
      * join : 회원가입한다.


### PR DESCRIPTION
Revision List

> - [x] 보안구역 정보 생성 시, 사용자-보안구역 테이블에 정보를 저장해야 이후 수정이 가능한지 확인 및 수정

> - [x] 보안구역 정보 수정 시, 기존 정보만 수정이 되고 위치 정보에 대한 수정

> - [x] handleUserAccessToSecurityArea API 실행 시, 인가 / 비인가된 사용자의 접근을 감지하는 메세지를 출력

> - [x] 인가 / 비인가 사용자가 보안구역에 접근했을 경우, 보안구역 출입 기록 (사용자-보안구역) 정보가 저장 및 생성

> - [x] 보안구역 출입 기록 (사용자-보안구역) 정보를 생성하는 시점에 비인가된 사용자는 경고 알림이 생성